### PR TITLE
changed node 24.9.0 to 24

### DIFF
--- a/.labspace/03-image-scanning.md
+++ b/.labspace/03-image-scanning.md
@@ -10,7 +10,7 @@ The app logic is implemented in the :fileLink[app.js]{path="app.js"} file.
 
 To follow modern best practices, we want to containerize the app and eventually deploy it to production. Before doing so, we must ensure the image is secure by using [Docker Scout](https://www.docker.com/products/docker-scout/)
 
-Our Dockerfile takes a multi-stage build approach and is based on the `node:24.9.0-trixie-slim` image.
+Our Dockerfile takes a multi-stage build approach and is based on the `node:24-trixie-slim` image.
 
 **Let’s build our image with SBOM and provenance metadata**
 This lab already has a :fileLink[Dockerfile]{path="Dockerfile"}, so you can easily build the image.
@@ -30,14 +30,11 @@ docker scout quickview $$orgname$$/demo-node-doi:v1
 ```
 You will see similar output:
 ```plaintext no-copy-button
-    i Base image was auto-detected. To get more accurate results, build images with max-mode provenance attestations.
-      Review docs.docker.com ↗ for more information.
+ Target      │  orgname/demo-node-doi:v1           │    0C     2H     2M    20L   
+    digest   │  771a1b07daa3                       │                              
+  Base image │  node:24-trixie-slim                │    0C     1H     2M    20L   
 
-  Target     │  demonstrationorg/demo-node-doi:v1  │    0C     2H     1M    18L   
-    digest   │  66cb8da420d8                       │                              
-  Base image │  node:24-trixie-slim                │    0C     2H     1M    18L   
-
-Policy status  FAILED  (5/10 policies met, 1 missing data)
+Policy status  FAILED  (6/10 policies met)
 
   Status │                              Policy                              │           Results            
 ─────────┼──────────────────────────────────────────────────────────────────┼──────────────────────────────
@@ -48,11 +45,10 @@ Policy status  FAILED  (5/10 policies met, 1 missing data)
   ✓      │ No embedded secrets (Rego)                                       │    0 deviations              
   !      │ Fixable critical or high vulnerabilities found                   │    0C     2H     0M     0L   
   ✓      │ No high-profile vulnerabilities                                  │    0C     0H     0M     0L   
-  !      │ No unapproved base images                                        │    No data                   
-  ✓      │ Missing supply chain attestation(s)                              │    2 deviations                   
-      
+  !      │ Unapproved base images found                                     │    1 deviation               
+  ✓      │ Supply chain attestations                                        │    0 deviations              
 ```
-As you can see, there are no CVEs at the application level, but the base image contains 2 high, 1 medium, and 18 low severity CVEs, so it is recommended to be updated. Additionally, the critical policies have failed:
+As you can see, there are no CVEs at the application level, but the base image contains a number of high, medium, and low severity CVEs, so it is recommended to be updated. Additionally, the critical policies have failed:
 
     1. No default non-root user found
     2. Fixable critical or high vulnerabilities found

--- a/.labspace/04-switch-to-dhi.md
+++ b/.labspace/04-switch-to-dhi.md
@@ -1,20 +1,20 @@
 # Making the Switch to Docker Hardened Images
 
-Switching to a Docker Hardened Image is straightforward. All we need to do is replace the base image `node:24.9.0-trixie-slim` with a DHI equivalent.
+Switching to a Docker Hardened Image is straightforward. All we need to do is replace the base image `node:24-trixie-slim` with a DHI equivalent.
 
 Docker Hardened Images come in two variants:
 
-* Dev variant (`$$orgname$$/dhi-node:24.9.0-debian13-dev`) – includes a shell and package managers, making it suitable for building and testing.
-* Runtime variant (`$$orgname$$/dhi-node:24.9.0-debian13`) – stripped down to only the essentials, providing a minimal and secure footprint for production.
+* Dev variant (`$$orgname$$/dhi-node:24-debian13-dev`) – includes a shell and package managers, making it suitable for building and testing.
+* Runtime variant (`$$orgname$$/dhi-node:24-debian13`) – stripped down to only the essentials, providing a minimal and secure footprint for production.
 
 This makes them perfect for use in multi-stage Dockerfiles. We can build the app in the dev image, then copy the built application into the runtime image, which will serve as the base for production.
 
-1. Update the `Dockerfile` to use the `$$orgname$$/dhi-node:24.9.0-debian13-dev` as a `dev` stage image and `$$orgname$$/dhi-node:24.9.0-debian13` as a `runtime` image
+1. Update the `Dockerfile` to use the `$$orgname$$/dhi-node:24-debian13-dev` as a `dev` stage image and `$$orgname$$/dhi-node:24-debian13` as a `runtime` image
 ```dockerfile
-FROM $$orgname$$/dhi-node:24.9.0-debian13-dev AS dev
+FROM $$orgname$$/dhi-node:24-debian13-dev AS dev
 ```
 ```dockerfile
-FROM $$orgname$$/dhi-node:24.9.0-debian13 AS prod
+FROM $$orgname$$/dhi-node:24-debian13 AS prod
 ```
 2. Looking back at the output for the `scout quickview`, the `No default non-root user found` policy was not met. To resolve this we typically need to add a non-root user to the Dockerfile description. The good news is that the DHI comes with a nonroot user built-in, so no changes should be made.
 
@@ -27,9 +27,9 @@ docker scout quickview $$orgname$$/demo-node-dhi:v1
 ```
 You will see similar output:
 ```plaintext no-copy-button
-  Target     │  $$orgname$$/demo-node-dhi:v1          │    0C     0H     0M     0L   
-    digest   │  cec31e6f0a36                          │                              
-  Base image │  $$orgname$$/dhi-node:24.9.0-debian13  │                              
+  Target     │  orgname/demo-node-dhi:v1          │    0C     0H     0M     0L   
+    digest   │  cec31e6f0a36                      │                              
+  Base image │  orgname/dhi-node:24-debian13      │                              
 
 Policy status  SUCCESS  (9/9 policies met)
 
@@ -49,34 +49,36 @@ Hooray! There are zero CVEs and policy violations now!
 
 **Let’s look at the image size and package count advantages of using distroless Hardened Images.**
 
-Docker Scout offers a helpful command `docker scout compare` that allows you to analyze and compare two images. We’ll use it to evaluate the difference in size and package footprint between `node:24.9.0-trixie-slim` and `dhi-node:24.9.0-debian13` based images.
+Docker Scout offers a helpful command `docker scout compare` that allows you to analyze and compare two images. We’ll use it to evaluate the difference in size and package footprint between `node:24-trixie-slim` and `dhi-node:24-debian13` based images.
 ```bash
 docker scout compare local://$$orgname$$/demo-node-dhi:v1 --to local://$$orgname$$/demo-node-doi:v1
 ```
-You will see a similar summary in the output:
+Scroll up the output and you will see a similar summary:
 ```plaintext no-copy-button
 ## Overview
   
                       │               Analyzed Image                │              Comparison Image                
   ────────────────────┼─────────────────────────────────────────────┼──────────────────────────────────────────────
-    Target            │  local://demonstrationorg/demo-node-dhi:v1  │  local://demonstrationorg/demo-node-doi:v1   
+    Target            │  local://orgname/demo-node-dhi:v1           │  local://orgname/demo-node-doi:v1   
       digest          │  e5b9ec7a980c                               │  66cb8da420d8                                
       tag             │  v1                                         │  v1                                          
       platform        │ linux/arm64                                 │ linux/arm64                                  
-      vulnerabilities │    0C     0H     0M     8L                  │    0C     2H     1M    18L                   
-                      │           -2     -1    -10                  │                                              
-      size            │ 59 MB (-41 MB)                              │ 100 MB                                       
-      packages        │ 648 (-248)                                  │ 896                                          
+      vulnerabilities │    0C     0H     0M     8L                  │    0C     2H     2M    20L                   
+                      │           -2     -2    -20                  │                                              
+      size            │ 59 MB (-40 MB)                              │ 97 MB                                       
+      packages        │ 648 (-214)                                  │ 858                                          
                       │                                             │                                              
-    Base image        │  demonstrationorg/dhi-node-smontri:24       │  node:24-trixie-slim                         
+    Base image        │  orgname/dhi-node:24                        │  node:24-trixie-slim                         
       tags            │ also known as                               │ also known as                                
-                      │                                             │   • current-trixie-slim                      
-                      │                                             │   • trixie-slim                              
-      vulnerabilities │    0C     0H     0M     0L                  │    0C     2H     1M    18L                   
+                      │                                             │   • 24.11-trixie-slim                     
+                      │                                             │   • 24.11.1-trixie-slim  
+                      |                                             |   • krypton-trixie-slim   
+                      |                                             |   • lts-trixie-slim      
+      vulnerabilities │    0C     0H     0M     0L                  │    0C     1H     2M    20L                   
   
 ```
 
-As you can see, the `dhi-node:24.9.0-debian13`–based image is **41 MB (around 40%) smaller**, contains **248 fewer packages**, and has nearly **zero CVEs** compared to the original `node:24.9.0-trixie-slim`–based image.
+As you can see, the `dhi-node:24-debian13`–based image is **40 MB (around 40%) smaller**, contains **214 fewer packages**, and has nearly **zero CVEs** compared to the original `node:24-trixie-slim`–based image.
 
 **Validate that the app works as expected**
 

--- a/.labspace/05-compliance.md
+++ b/.labspace/05-compliance.md
@@ -4,9 +4,9 @@
 
 In addition to providing a minimal and secure base image, Docker Hardened Images include a comprehensive set of attestations.
 
-You can run the following command to see the full list of attestations for `dhi-node:24.9.0-debian13`:
+You can run the following command to see the full list of attestations for `dhi-node:24-debian13`:
 ```bash
-docker scout attest list $$orgname$$/dhi-node:24.9.0-debian13
+docker scout attest list $$orgname$$/dhi-node:24-debian13
 ```
 In the output you will see the list of available attestations, such as:
 * CycloneDX SBOM (A software bill of materials in CycloneDX format, listing components, libraries, and versions.)
@@ -26,7 +26,7 @@ In the output you will see the list of available attestations, such as:
 
 DHI provides SBOMs in the CycloneDX, SPDX, or Scout formats. To view a specific SBOM file, such as the SPDX SBOM that is widely adopted in open-source ecosystems, you can use the `docker scout attest get` command:
 ```bash
-docker scout attest get $$orgname$$/dhi-node:24.9.0-debian13 \
+docker scout attest get $$orgname$$/dhi-node:24-debian13 \
 --predicate-type https://spdx.dev/Document
 ```
 
@@ -36,9 +36,9 @@ FIPS 140 compliance is required or strongly recommended in many regulated enviro
 
 DHIs include variants that use cryptographic modules validated under FIPS 140. 
 
-You can retrieve and inspect the FIPS attestation for the `$$orgname$$/dhi-node:24.9.0-debian13-fips` using the Docker Scout CLI:
+You can retrieve and inspect the FIPS attestation for the `$$orgname$$/dhi-node:24-debian13-fips` using the Docker Scout CLI:
 ```bash
-docker scout attest get --predicate-type https://docker.com/dhi/fips/v0.1 --predicate $$orgname$$/dhi-node:24.9.0-debian13-fips
+docker scout attest get --predicate-type https://docker.com/dhi/fips/v0.1 --predicate $$orgname$$/dhi-node:24-debian13-fips
 ```
 In the output you'll see the CMVP # and the FIPS Provider name, for example:
 ```plaintext no-copy-button
@@ -55,7 +55,7 @@ Docker also provides a signed STIG scan attestation for each STIG-hardened image
 
 You can retrieve and inspect a STIG scan attestation using the Docker Scout CLI:
 ```bash
-docker scout attest get --predicate-type https://docker.com/dhi/stig/v0.1 --predicate $$orgname$$/dhi-node:24.9.0-debian13-fips
+docker scout attest get --predicate-type https://docker.com/dhi/stig/v0.1 --predicate $$orgname$$/dhi-node:24-debian13-fips
 ```
 **Integration with external security tools**
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:24.9.0-trixie-slim AS dev
+FROM node:24-trixie-slim AS dev
 
 ENV BLUEBIRD_WARNINGS=0 \
 NODE_ENV=production \
@@ -22,7 +22,7 @@ COPY . .
 
 
 #-- Prod stage --
-FROM node:24.9.0-trixie-slim AS prod
+FROM node:24-trixie-slim AS prod
 
 WORKDIR /app
 


### PR DESCRIPTION
Fix for https://github.com/dockersamples/labspace-dhi-node/issues/6 where dhi-node:24.9.0 is not available in the recently mirrored dhi node repo