### PR TITLE
Update package.json to fix 1H vulnerability

### DIFF
--- a/project/package.json
+++ b/project/package.json
@@ -12,7 +12,7 @@
     "test": "jest --testTimeout=60000"
   },
   "devDependencies": {
-    "axios": "^1.6.0",
+    "axios": "^1.15.1",
     "jest": "^29.7.0",
     "testcontainers": "^10.13.2"
   },
@@ -22,5 +22,8 @@
   },
   "dependencies": {
     "express": "^5.2.1"
+  },
+  "overrides": {
+    "path-to-regexp": "^8.4.0"
   }
 }


### PR DESCRIPTION
This PR fixes https://github.com/dockersamples/labspace-dhi-node/issues/14 issue.
It overrides the entry for "path-to-regexp" to "^8.4.0" version.  

